### PR TITLE
fix: expose error message when call to AWS fails

### DIFF
--- a/PynamicDNS.py
+++ b/PynamicDNS.py
@@ -36,7 +36,9 @@ def get_record_value():
             RecordName=DNS_RECORD,
             RecordType='A',
         )
-    except:
+    except Exception as e:
+        print("Error when sending a request to AWS (test_dns_answer):") 
+        print(e)
         response = 'FAILED'
 
     try:


### PR DESCRIPTION
Hi! 

Thanks for this script, I found it very useful!

If you are open to PRs: I added those two lines while debugging my setup (turns out it was a credentials issue). 

